### PR TITLE
Including filters as input for evaluation

### DIFF
--- a/dataloop.json
+++ b/dataloop.json
@@ -77,6 +77,11 @@
                 "type": "Dataset",
                 "name": "dataset",
                 "description": "Dataloop Dataset Entity"
+              },
+              {
+                "type": "Json",
+                "name": "filters",
+                "description": "Filter to select items over which to run evaluation"
               }
             ],
             "output": [


### PR DESCRIPTION
I have tested this change here:
https://rc-con.dataloop.ai/projects/b8eeea8c-ba02-463e-b975-89a50b7e8448/services/6666dcba62a7f4e200e9cf15?tab=logs

it was an eval on a dataset with 8 items, 3 in test set. It ran only over the 3 test set items.